### PR TITLE
Add platformio configuration for the things uno.

### DIFF
--- a/ttnulmdust/.gitignore
+++ b/ttnulmdust/.gitignore
@@ -1,0 +1,2 @@
+.pioenvs
+.piolibdeps

--- a/ttnulmdust/platformio.ini
+++ b/ttnulmdust/platformio.ini
@@ -1,0 +1,24 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; http://docs.platformio.org/page/projectconf.html
+
+
+[platformio]
+src_dir = .
+
+[env:thingsuno]
+platform = atmelavr
+board = leonardo
+framework = arduino
+monitor_speed= 9600
+lib_deps =
+  DHT sensor library
+  TheThingsNetwork
+  Adafruit Unified Sensor
+  


### PR DESCRIPTION
This adds a platformio configuration file, specifically for the things uno board. Platformio allows you to build Arduino projects from the command line, even automatically on a continuous integration platform like Travis. Libraries and toolchains required for building are downloaded automatically (and cached locally). For example, to build and upload the software to the board using platformio:
  pio run -t upload

Platformio itself can be installed by install python-pip (apt-get install python-pip) and then using pip to install platformio (pip install platformio)