### PR TITLE
Removed unused variable in function 'median'.

### DIFF
--- a/ttnulmdust/ttnulmdust.ino
+++ b/ttnulmdust/ttnulmdust.ino
@@ -222,7 +222,6 @@ void loop() {
 // calculate the median
 float median(float samples[], int m) {
     float sorted[m];
-    float temp=0.0;
 
     for(int i=0;i<m;i++){
         sorted[i]=samples[i];


### PR DESCRIPTION
As described, this removes an unused variable in function median, fixing a compiler warning.