### PR TITLE
BME280 und DHT in eigene Klassen

### DIFF
--- a/ttnulmdust/BME280_Sensor.cpp
+++ b/ttnulmdust/BME280_Sensor.cpp
@@ -1,0 +1,82 @@
+#include <Arduino.h>
+#include "BME280_Sensor.h"
+#include "Adafruit_BME280.h"
+
+BME280_Sensor::BME280_Sensor(Serial_ serial, uint8_t bme280Address)
+{
+    debugSerial = serial;
+    address = bme280Address;
+}
+
+// ****************************************************************
+// Initialize the weather sensor
+// ****************************************************************
+bool BME280_Sensor::setup()
+{
+	bool status = bme280.begin(address);  
+    if (!status) 
+    {
+        debugSerial.println(F("Could not find a valid BME280 sensor, check wiring!"));
+        while (1);
+    }
+
+    // set BME280 weather station mode (save some energy)
+    bme280.setSampling(Adafruit_BME280::MODE_FORCED,
+                        Adafruit_BME280::SAMPLING_X1, // temperature
+                        Adafruit_BME280::SAMPLING_X1, // pressure
+                        Adafruit_BME280::SAMPLING_X1, // humidity
+                        Adafruit_BME280::FILTER_OFF);
+
+    return true;
+}
+
+// ****************************************************************
+//  read Temperature
+// ****************************************************************
+int16_t BME280_Sensor::readTemperature(void)
+{
+    float temperature = bme280.readTemperature();
+    if (isnan(temperature))
+    {
+        return -1;
+    }
+
+    debugSerial.print(F("Temperature: "));
+    debugSerial.println(String(temperature));
+
+    return round(temperature * 100);
+}
+
+// ****************************************************************
+//  read barometric pressure
+// ****************************************************************
+int16_t BME280_Sensor::readPressure(void)
+{
+    float pressure = bme280.readPressure();
+    if (isnan(pressure))
+    {
+        return -1;
+    }
+
+    debugSerial.print(F("Pressure: "));
+    debugSerial.println(String(pressure));
+
+    return round(pressure * 100);
+}
+
+// ****************************************************************
+//  read humidity
+// ****************************************************************    
+int16_t BME280_Sensor::readHumidity(void)
+{
+    float humidity = bme280.readHumidity();
+    if (isnan(humidity))
+    {
+        return -1;
+    }
+
+    debugSerial.print(F("Humidity: "));
+    debugSerial.println(String(humidity));
+
+    return round(humidity * 100);
+}

--- a/ttnulmdust/BME280_Sensor.h
+++ b/ttnulmdust/BME280_Sensor.h
@@ -1,0 +1,28 @@
+#ifndef __BME280_SENSOR_H__
+#define __BME280_SENSOR_H__
+
+#include <Arduino.h>
+#include "Adafruit_BME280.h"
+
+// ****************************************************************
+//                      BME280 Sensor class
+//  used to move out the code for the sensors from the main sketch
+//  NOTE: the methods shall return the normalized "int" values for
+//        the data transmission
+// ****************************************************************
+class BME280_Sensor
+{
+    public:
+        BME280_Sensor(Serial_ serial, uint8_t address);
+        bool setup();
+        int16_t readTemperature(void);
+        int16_t readPressure(void);
+        int16_t readHumidity(void);
+
+    private:
+        Serial_ debugSerial;
+        uint8_t address;
+        Adafruit_BME280 bme280;
+};
+
+#endif

--- a/ttnulmdust/DHT_Sensor.cpp
+++ b/ttnulmdust/DHT_Sensor.cpp
@@ -1,0 +1,60 @@
+#include <Arduino.h>
+#include "DHT_Sensor.h"
+#include "DHT.h"
+
+DHT_Sensor::DHT_Sensor(Serial_ serial, uint8_t pin, uint8_t type) : dht(pin, type)
+{
+    debugSerial = serial;
+}
+
+// ****************************************************************
+// Initialize the weather sensor
+// ****************************************************************
+bool DHT_Sensor::setup()
+{
+    dht.begin();
+
+    return true;
+}
+
+// ****************************************************************
+//  read Temperature
+// ****************************************************************
+int16_t DHT_Sensor::readTemperature(void)
+{
+    float temperature = dht.readTemperature();
+    if (isnan(temperature))
+    {
+        return -1;
+    }
+
+    debugSerial.print(F("Temperature: "));
+    debugSerial.println(String(temperature));
+
+    return round(temperature * 100);
+}
+
+// ****************************************************************
+//  read barometric pressure
+// ****************************************************************
+int16_t DHT_Sensor::readPressure(void)
+{
+    return -1;
+}
+
+// ****************************************************************
+//  read humidity
+// ****************************************************************
+int16_t DHT_Sensor::readHumidity(void)
+{
+    float humidity = dht.readHumidity();
+    if (isnan(humidity))
+    {
+        return -1;
+    }
+
+    debugSerial.print(F("Humidity: "));
+    debugSerial.println(String(humidity));
+
+    return round(humidity * 100);
+}

--- a/ttnulmdust/DHT_Sensor.h
+++ b/ttnulmdust/DHT_Sensor.h
@@ -1,0 +1,27 @@
+#ifndef __DHT_SENSOR_H__
+#define __DHT_SENSOR_H__
+
+#include <Arduino.h>
+#include "DHT.h"
+
+// ****************************************************************
+//                      DHT Sensor class
+//  used to move out the code for the sensors from the main sketch
+//  NOTE: the methods shall return the normalized "int" values for
+//        the data transmission
+// ****************************************************************
+class DHT_Sensor
+{
+    public:
+        DHT_Sensor(Serial_ serial, uint8_t pin, uint8_t type);
+        bool setup();
+        int16_t readTemperature(void);
+        int16_t readPressure(void);
+        int16_t readHumidity(void);
+
+    private:
+        Serial_ debugSerial;
+        DHT dht;
+};
+
+#endif


### PR DESCRIPTION
Hi,
ich habe mal ein wenig weiter am Quellcode gearbeitet und ihn ein wenig aufgeräumt. Dabei habe ich die Logik für den BME280 und den DHT in eine eigene "Wrapperklasse" gepackt, damit die Logik im Hauptprogrammteil einfacher wird und weniger "ifdefs" benötigt. So lange ein neuer Sensor die entsprechenden Methoden implementiert, sollte er ganz einfach hinzuzufügen sein. Die Methoden der Sensorimplementierung sollen dabei immer den Wert zurückliefern, der nachher in das Array für die Datenübertragung gepackt wird (in diesem Fall also "round(x * 100)").
Wird ein Wert nicht unterstützt, so liefert die entsprechende Methode, die den Wert zurückliefern sollte, eine "-1" zurück. Das sollte für Momentan ist das nur beim DHT Sensor zum Auslesen des Luftdrucks der Fall.

Apropo Luftdruck: ich würde den Luftdruck des BME280 gerne mit übertragen, bin mir aber nicht sicher, ob ich da auf eurer Seite irgendetwas mit kaputt mache. Ist es ok, wenn ich an den Datenteil noch zwei Bytes mit dem Luftdruck dahinterhänge oder mache ich euch damit im Backend irgendetwas kaputt?

Desweiteren habe ich die Strings in den Flash Speicher gepackt (mit "F(...)") und habe damit ein wenig Speicher sparen können.

CU Tim

