### PR TITLE
Konfiguration in einer eigenen Datei

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ A Arduino sketch to measure particulates in the air via the SDS011 sensor and se
 1. Connect the SDS011 to the PINs configured in the sketch (PIN 8 and 9 are preconfigured)
 2. Connect the 5V and GND pins
 3. Connect the DHT sensor to PIN 10, 3.3v and GND or connect the BME280 sensor to PIN SCL, SDA, 3.3V and GND.
-4. Fill in your TTN credentials
-5. If you are using a BME280 sensor, uncomment the "#define BME280" line in the sketch
-6. Make sure you have the TheThingsNetwork, DHT library and BME280 library installed,
+4. Copy the file "configuration.h.default" to "configuration.h"
+5. Fill in your TTN credentials in the "configuration.h"
+6. If you are using a BME280 sensor, uncomment the "#define BME280" line in the "configuration.h"
+7. Make sure you have the TheThingsNetwork, DHT library and BME280 library installed,
    you can get them from the Arduino Library Manager (see below)
-7. Write the sketch to the The Things Uno
+8. Write the sketch to the The Things Uno
 
 ## Quick explanation what this does
 1. sleeps for a given amount of time.

--- a/bauanleitung.md
+++ b/bauanleitung.md
@@ -164,14 +164,21 @@ abgeschlossen ist.
 Bevor der Arduino-Sketch auf den Arduino geflasht wird,
 müssen noch die TTN Daten deines Devices (siehe vorigen Schritt)
 hinzugefügt werden.
+Die Konfiguration befindet sich in der "configuration.h" Datei. Sollte
+die Datei noch nicht existieren, so kopiert die Standard Konfiguration
+"configuration.h.default" nach "configuration.h".
 
-Öffne die Datei ttnulmdust.ino und ersetzte dort die zwei Zeilen
+Öffne die Datei "configuation.h" und ersetzte dort die zwei Zeilen
 ```
     const char *devAddr = "";
     const char *appSKey = "";
 ```
 mit den zwei Zeilen, die du am unteren Ende der Device Seite bei TTN
-siehst.
+siehst ("Example Code").
+
+Solltest du einen BME280 Sensor verwenden, dann kommentiere bitte die
+Zeile "#define BME280_SENSOR" ein. Der Code wird dann mit der
+Unterstützug für den BME280 gebaut.
 
 Danach kannst du wie gewohnt über die Arduino IDE den Flashvorgang starten.
 

--- a/ttnulmdust/.gitignore
+++ b/ttnulmdust/.gitignore
@@ -1,3 +1,5 @@
 .pioenvs
 .piolibdeps
 .vscode
+.vscode/*
+configuration.h

--- a/ttnulmdust/BME280_Sensor.cpp
+++ b/ttnulmdust/BME280_Sensor.cpp
@@ -1,0 +1,82 @@
+#include <Arduino.h>
+#include "BME280_Sensor.h"
+#include "Adafruit_BME280.h"
+
+BME280_Sensor::BME280_Sensor(Serial_ serial, uint8_t bme280Address)
+{
+    debugSerial = serial;
+    address = bme280Address;
+}
+
+// ****************************************************************
+// Initialize the weather sensor
+// ****************************************************************
+bool BME280_Sensor::setup()
+{
+	bool status = bme280.begin(address);  
+    if (!status) 
+    {
+        debugSerial.println(F("Could not find a valid BME280 sensor, check wiring!"));
+        while (1);
+    }
+
+    // set BME280 weather station mode (save some energy)
+    bme280.setSampling(Adafruit_BME280::MODE_FORCED,
+                        Adafruit_BME280::SAMPLING_X1, // temperature
+                        Adafruit_BME280::SAMPLING_X1, // pressure
+                        Adafruit_BME280::SAMPLING_X1, // humidity
+                        Adafruit_BME280::FILTER_OFF);
+
+    return true;
+}
+
+// ****************************************************************
+//  read Temperature
+// ****************************************************************
+int16_t BME280_Sensor::readTemperature(void)
+{
+    float temperature = bme280.readTemperature();
+    if (isnan(temperature))
+    {
+        return -1;
+    }
+
+    debugSerial.print(F("Temperature: "));
+    debugSerial.println(String(temperature));
+
+    return round(temperature * 100);
+}
+
+// ****************************************************************
+//  read barometric pressure
+// ****************************************************************
+int16_t BME280_Sensor::readPressure(void)
+{
+    float pressure = bme280.readPressure();
+    if (isnan(pressure))
+    {
+        return -1;
+    }
+
+    debugSerial.print(F("Pressure: "));
+    debugSerial.println(String(pressure));
+
+    return round(pressure * 100);
+}
+
+// ****************************************************************
+//  read humidity
+// ****************************************************************    
+int16_t BME280_Sensor::readHumidity(void)
+{
+    float humidity = bme280.readHumidity();
+    if (isnan(humidity))
+    {
+        return -1;
+    }
+
+    debugSerial.print(F("Humidity: "));
+    debugSerial.println(String(humidity));
+
+    return round(humidity * 100);
+}

--- a/ttnulmdust/BME280_Sensor.h
+++ b/ttnulmdust/BME280_Sensor.h
@@ -1,0 +1,28 @@
+#ifndef __BME280_SENSOR_H__
+#define __BME280_SENSOR_H__
+
+#include <Arduino.h>
+#include "Adafruit_BME280.h"
+
+// ****************************************************************
+//                      BME280 Sensor class
+//  used to move out the code for the sensors from the main sketch
+//  NOTE: the methods shall return the normalized "int" values for
+//        the data transmission
+// ****************************************************************
+class BME280_Sensor
+{
+    public:
+        BME280_Sensor(Serial_ serial, uint8_t address);
+        bool setup();
+        int16_t readTemperature(void);
+        int16_t readPressure(void);
+        int16_t readHumidity(void);
+
+    private:
+        Serial_ debugSerial;
+        uint8_t address;
+        Adafruit_BME280 bme280;
+};
+
+#endif

--- a/ttnulmdust/DHT_Sensor.cpp
+++ b/ttnulmdust/DHT_Sensor.cpp
@@ -1,0 +1,60 @@
+#include <Arduino.h>
+#include "DHT_Sensor.h"
+#include "DHT.h"
+
+DHT_Sensor::DHT_Sensor(Serial_ serial, uint8_t pin, uint8_t type) : dht(pin, type)
+{
+    debugSerial = serial;
+}
+
+// ****************************************************************
+// Initialize the weather sensor
+// ****************************************************************
+bool DHT_Sensor::setup()
+{
+    dht.begin();
+
+    return true;
+}
+
+// ****************************************************************
+//  read Temperature
+// ****************************************************************
+int16_t DHT_Sensor::readTemperature(void)
+{
+    float temperature = dht.readTemperature();
+    if (isnan(temperature))
+    {
+        return -1;
+    }
+
+    debugSerial.print(F("Temperature: "));
+    debugSerial.println(String(temperature));
+
+    return round(temperature * 100);
+}
+
+// ****************************************************************
+//  read barometric pressure
+// ****************************************************************
+int16_t DHT_Sensor::readPressure(void)
+{
+    return -1;
+}
+
+// ****************************************************************
+//  read humidity
+// ****************************************************************
+int16_t DHT_Sensor::readHumidity(void)
+{
+    float humidity = dht.readHumidity();
+    if (isnan(humidity))
+    {
+        return -1;
+    }
+
+    debugSerial.print(F("Humidity: "));
+    debugSerial.println(String(humidity));
+
+    return round(humidity * 100);
+}

--- a/ttnulmdust/DHT_Sensor.h
+++ b/ttnulmdust/DHT_Sensor.h
@@ -1,0 +1,27 @@
+#ifndef __DHT_SENSOR_H__
+#define __DHT_SENSOR_H__
+
+#include <Arduino.h>
+#include "DHT.h"
+
+// ****************************************************************
+//                      DHT Sensor class
+//  used to move out the code for the sensors from the main sketch
+//  NOTE: the methods shall return the normalized "int" values for
+//        the data transmission
+// ****************************************************************
+class DHT_Sensor
+{
+    public:
+        DHT_Sensor(Serial_ serial, uint8_t pin, uint8_t type);
+        bool setup();
+        int16_t readTemperature(void);
+        int16_t readPressure(void);
+        int16_t readHumidity(void);
+
+    private:
+        Serial_ debugSerial;
+        DHT dht;
+};
+
+#endif

--- a/ttnulmdust/configuration.h.default
+++ b/ttnulmdust/configuration.h.default
@@ -1,0 +1,47 @@
+/*****************************************************
+ * TTN Ulm particulate matter sensor
+ *
+ * To configure the sensor, enter your The Things Network
+ * keys in "*appEui" and "*appKey" (you can copy the 
+ * values directly from the TTN Console).
+ * 
+ * To use a BME280 sensor instead of the DHT22, just
+ * uncomment the "#define BME280_SENSOR" line. In case
+ * that the BME280 is not found, you can configure the
+ * BME_ADDRESS below.
+ *
+******************************************************/
+
+// copy and paste these values from your TTN console application
+const char *appEui = "";
+const char *appKey = "";
+
+// PIN configuration for the SDS011 dust sensor
+#define PIN_RX 8       // connect the SDS011 RX pin to this The Things Uno pin
+#define PIN_TX 9       // connect the SDS011 TX pin to this The Things Uno pin
+
+// DHT configuration
+#define DHTPIN 10      // connect the DHT22 PIN to this The Things Uno PIN
+#define DHTTYPE DHT22   // DHT 22  (AM2302), AM2321
+
+// uncomment to use BME280 weather sensor
+// #define BME280_SENSOR
+
+// default I2C address for the BME280 is 0x77
+// if your chinese import does not work, try to use 0x76 instead
+#define BME_ADDRESS 0x77
+
+// timeouts for power saving and measurements
+#define SLEEP_ON 1     // if the fan should go to sleep
+#define SLEEP_TIME  5  // sleep for x minutes between readings
+#define FAN_SPINUP 30  // how long should the fan 'clean' itself before measurements are taken (if SLEEP_ON = 1)
+#define PWR_DOWN 0     // set to 1 to use power down mode of µC, new flash needs manual reset
+
+//***************************************************
+// You don't need to change anyhting below this line
+//***************************************************
+#define DEBUGRATE 9600
+#define LORA_RATE 57600
+
+#define loraSerial Serial1
+#define debugSerial Serial

--- a/ttnulmdust/ttnulmdust.ino
+++ b/ttnulmdust/ttnulmdust.ino
@@ -4,6 +4,11 @@
  * Reads data from a SDS011 sensor and send the data
  * to the TTN network via LoRaWAN.
  *
+ * To configure your particulate matter sensor, copy
+ * the configuration.h.default file to configuration.h
+ * and enter the correct values for your sensor (e.g.
+ * the keys for the The Things Network).
+ * 
  * Works like this:
  * 1) sleeps for a given amount of time.
  * 2) spins up the fan for a minute to clean the fan
@@ -15,61 +20,20 @@
  *
 ******************************************************/
 #include "SDS011.h"
-
-// uncomment to use BME280 weather sensor
-// #define BME280_SENSOR
-
-#ifdef BME280_SENSOR
-    // default I2C address for the BME280 is 0x77
-    // if your chinese import does not work, try to use 0x76 instead
-    #define BME_ADDRESS 0x76 
-
-    #include "BME280_Sensor.h"
-#else
-    // DHT configuration
-    #define DHTPIN 10      // connect the DHT22 PIN to this The Things Uno PIN
-    #define DHTTYPE DHT22   // DHT 22  (AM2302), AM2321
-
-    #include <DHT_Sensor.h>
-#endif
-
+#include "configuration.h"
 #include <TheThingsNetwork.h>
+#include "sleep_32u4.h"
 
-//*******************************
-// User variables
-//*******************************
-
-// copy and paste these values from your TTN console application
-const char *appEui = "";
-const char *appKey = "";
-
-// PIN configuration for the SDS011 dust sensor
-#define PIN_RX 8       // connect the SDS011 RX pin to this The Things Uno pin
-#define PIN_TX 9       // connect the SDS011 TX pin to this The Things Uno pin
-
-#define SLEEP_ON 1     // if the fan should go to sleep
-#define SLEEP_TIME  5  // sleep for x minutes between readings
-#define FAN_SPINUP 30  // how long should the fan 'clean' itself before measurements are taken (if SLEEP_ON = 1)
-#define PWR_DOWN 0     // set to 1 to use power down mode of µC, new flash needs manual reset
-
-//***************************************************
-// You don't need to change anyhting below this line
-//***************************************************
-
-#define DEBUGRATE 9600
-#define LORA_RATE 57600
-
-#define loraSerial Serial1
-#define debugSerial Serial
-
+// include and create an instance of the weather sensor
 #ifdef BME280_SENSOR
+    #include "BME280_Sensor.h"
+
     BME280_Sensor weatherSensor(debugSerial, BME_ADDRESS); // I2C - connect SCL to SCL and SDA to SDA
 #else
+    #include <DHT_Sensor.h>
+
     DHT_Sensor weatherSensor(debugSerial, DHTPIN, DHTTYPE);
 #endif
-
-// Power saving
-#include "sleep_32u4.h"
 
 // sleep time between fan spinup and sleep in minutes.
 volatile uint16_t iWakeCntr = 0;


### PR DESCRIPTION
Hi,
ich habe die Konfiguration in eine eigene Datei ausgelagert. Das macht die Konfiguration übersichtlicher. Desweiteren habe ich eine "configuation.h.default" hinzugefügt, die man erst als "configuration.h" reinkopieren muss. Die "configuration.h" liegt im ".gitignore", sodass man seinen Sensor konfigurieren kann ohne die Gefahr zu haben, dass man hier seine Zugangsdaten aus Versehen committet :-).

CU Tim