### PR TITLE
Avoid integer truncating when dividing by 10 to obtain PM10/PM2.5 fro…

### DIFF
--- a/ttnulmdust/SDS011.cpp
+++ b/ttnulmdust/SDS011.cpp
@@ -65,8 +65,8 @@ int SDS011::read(float *p25, float *p10) {
 		}
 		len++;
 		if (len == 10 && checksum_ok == 1) {
-			*p10 = pm10_serial/10;
-			*p25 = pm25_serial/10;
+			*p10 = pm10_serial/10.0;
+			*p25 = pm25_serial/10.0;
 			len = 0; checksum_ok = 0; pm10_serial = 0.0; pm25_serial = 0.0; checksum_is = 0;
 			error = 0;
 		}


### PR DESCRIPTION
…m SDS011 reading.

This improves resolution of the calculation to 0.1 ug/m3 instead of 1 ug/m3.